### PR TITLE
Fix spelling in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Example:
 	path : [ "timers", "API.get" ],
 	metric : "mean",
 	label : "Avg Get latency",
-	// calculate an avarage of the metric values from the separate results 
+        // calculate an average of the metric values from the separate results
 	operation : "avg"
 }
 ```
@@ -239,7 +239,7 @@ We can show the top 5 latencies of API calls that had over 2 requests in the las
 	keyRegex : "API\\.(.*)",
 	metric : "mean",
 	label : "API $1 latency",
-	// calculate an avarage of the metric values from the separate results 
+        // calculate an average of the metric values from the separate results
 	operation : "avg",
 	// show only the top 5 (according to the last metric value)
 	showTop : 5,

--- a/examples/example.html
+++ b/examples/example.html
@@ -145,7 +145,7 @@
 			metric : "mean",
 			label : "Avg Get latency",
 			yaxis : 2,
-			// calculate an avarage of the metric values from the separate results 
+                        // calculate an average of the metric values from the separate results
 			operation : "avg"
 		}, {
 			path : [ "timers" ],
@@ -153,7 +153,7 @@
 			metric : "mean",
 			label : "$1 Get latency",
 			yaxis : 2,
-			// calculate an avarage of the metric values from the separate results 
+                        // calculate an average of the metric values from the separate results
 			operation : "avg",
 			// show only the top 5 (according to the last metric value)
 			showTop : 5,


### PR DESCRIPTION
## Summary
- correct 'avarage' to 'average' in README and example

## Testing
- `grep -R "avarage" -n`

------
https://chatgpt.com/codex/tasks/task_e_684052dfb7e4832e96944db9a61849d9