### PR TITLE
Fix showBottom calculation

### DIFF
--- a/json2flot.js
+++ b/json2flot.js
@@ -404,7 +404,8 @@
 						for ( var n = 0; n < stop; n++) {
 							data.push(sortedMetrics[n].metric);
 						}
-						var start = Math.max(stop, sortedMetrics.length - Math.min(0, metric.showBottom));
+                                                var bottom = Math.max(0, metric.showBottom || 0);
+                                                var start = Math.max(stop, sortedMetrics.length - bottom);
 						for ( var n = start; n < sortedMetrics.length; n++) {
 							data.push(sortedMetrics[n].metric);
 						}


### PR DESCRIPTION
## Summary
- use correct showBottom logic when selecting bottom N metrics

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684051eb47bc832eb95311afd35ddb75