### PR TITLE
Add unit test for showBottom and export internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Example:
 	path : [ "timers", "API.get" ],
 	metric : "mean",
 	label : "Avg Get latency",
-	// calculate an avarage of the metric values from the separate results 
+        // calculate an average of the metric values from the separate results
 	operation : "avg"
 }
 ```
@@ -239,7 +239,7 @@ We can show the top 5 latencies of API calls that had over 2 requests in the las
 	keyRegex : "API\\.(.*)",
 	metric : "mean",
 	label : "API $1 latency",
-	// calculate an avarage of the metric values from the separate results 
+        // calculate an average of the metric values from the separate results
 	operation : "avg",
 	// show only the top 5 (according to the last metric value)
 	showTop : 5,
@@ -261,3 +261,6 @@ We can show the top 5 latencies of API calls that had over 2 requests in the las
 }
 ```
  
+## Tests
+Run `npm test` to execute the Node-based unit tests.
+

--- a/examples/example.html
+++ b/examples/example.html
@@ -145,7 +145,7 @@
 			metric : "mean",
 			label : "Avg Get latency",
 			yaxis : 2,
-			// calculate an avarage of the metric values from the separate results 
+                        // calculate an average of the metric values from the separate results
 			operation : "avg"
 		}, {
 			path : [ "timers" ],
@@ -153,7 +153,7 @@
 			metric : "mean",
 			label : "$1 Get latency",
 			yaxis : 2,
-			// calculate an avarage of the metric values from the separate results 
+                        // calculate an average of the metric values from the separate results
 			operation : "avg",
 			// show only the top 5 (according to the last metric value)
 			showTop : 5,

--- a/json2flot.js
+++ b/json2flot.js
@@ -199,10 +199,10 @@
 		this.initMetric = prepareMetric;
 	}
 
-	/**
-	 * An array of graph object
-	 */
-	var graphs = [];
+        /**
+         * An array of graph objects.
+         */
+        var graphs = [];
 	/**
 	 * An array of URLs to fetch the metrics JSON from
 	 */
@@ -404,10 +404,11 @@
 						for ( var n = 0; n < stop; n++) {
 							data.push(sortedMetrics[n].metric);
 						}
-						var start = Math.max(stop, sortedMetrics.length - Math.min(0, metric.showBottom));
-						for ( var n = start; n < sortedMetrics.length; n++) {
-							data.push(sortedMetrics[n].metric);
-						}
+                                                var bottom = Math.max(0, metric.showBottom || 0);
+                                                var start = Math.max(stop, sortedMetrics.length - bottom);
+                                                for ( var n = start; n < sortedMetrics.length; n++) {
+                                                        data.push(sortedMetrics[n].metric);
+                                                }
 					}
 				} else {
 					var metricValid = isMetricValid(metric, metricResults);
@@ -604,7 +605,17 @@
 		} else if (deferred !== firstParam) {
 			deferred.resolveWith(deferred, length ? [ firstParam ] : []);
 		}
-		return deferred.promise();
-	};
+                return deferred.promise();
+       };
+
+       json2flot._test = {
+               processMetrics: processMetrics,
+               UpdateResults: UpdateResults,
+               MetricsGraph: MetricsGraph
+       };
 
 }(window.json2flot = window.json2flot || {}, jQuery));
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = window.json2flot;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "json2flot",
+  "version": "1.0.0",
+  "description": "json2flot utilities",
+  "scripts": {
+    "test": "node tests/test.js"
+  }
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+
+// minimal jQuery/flot mock
+class MockPlot {
+  constructor() {
+    this.dataSet = null;
+  }
+  setData(data) { this.dataSet = data; }
+  setupGrid() {}
+  draw() {}
+}
+
+global.window = {};
+global.jQuery = global.$ = {
+  plot: function() { return new MockPlot(); },
+  isFunction: function(fn) { return typeof fn === 'function'; },
+};
+
+const json2flot = require('../json2flot.js');
+const { processMetrics, UpdateResults } = json2flot._test;
+
+// ensure updates are processed
+json2flot.setMetricURLs([]);
+json2flot.startUpdate();
+
+const graph = json2flot.addGraph('#ph', {}, [{
+  path: ['metrics'],
+  keyRegex: 'm(.*)',
+  metric: 'value',
+  label: 'm$1',
+  showTop: 0,
+  showBottom: 2
+}], 10);
+
+const metricsData = {
+  metrics: {
+    m1: { value: 10 },
+    m2: { value: 30 },
+    m3: { value: 20 },
+    m4: { value: 5 }
+  }
+};
+const updater = new UpdateResults(new Date());
+updater.results.push(metricsData);
+
+processMetrics(updater);
+json2flot.stopUpdate();
+
+const labels = graph.plot.dataSet.map(m => m.path[m.path.length - 1]).sort();
+assert.deepStrictEqual(labels, ['m1', 'm4']);
+
+console.log('Test passed');


### PR DESCRIPTION
## Summary
- fix `showBottom` logic in `json2flot.js`
- expose internals for test via `json2flot._test`
- provide Node test under `tests/`
- document `npm test` in README
- merge latest changes from `master`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684052fcfa60832e81c1fbbdf7ed5785